### PR TITLE
Pass captured error to 'slack_error_notification'

### DIFF
--- a/lib/sinatra/slack/instance_helpers.rb
+++ b/lib/sinatra/slack/instance_helpers.rb
@@ -27,7 +27,7 @@ module Sinatra
         s_resp
       end
 
-      def slack_error_notification
+      def slack_error_notification(_error)
         slack_response '' do |r|
           r.text = 'Ups, something went wrong'
         end
@@ -50,7 +50,7 @@ module Sinatra
         yield
       rescue StandardError => ex
         logger.error ex.full_message
-        channel.send(slack_error_notification)
+        channel.send(slack_error_notification(ex))
       end
 
       # Checks for Slack defined HTTP headers


### PR DESCRIPTION
Hi there, first of all, thank you for this repo. It's providing a simpler interface for handling Slack slash commands in a really straight-forward manner.

This PR allows us to receive the error being sent to `slack_error_notification`. When overriding this method to provide custom messages, without the error it is impossible to know what failed.

P.S. Since I'm actively working with this library at this moment, is it okay if I open a few PRs?